### PR TITLE
Let users post longer text submissions

### DIFF
--- a/migrations/versions/1e129b98f546_.py
+++ b/migrations/versions/1e129b98f546_.py
@@ -1,0 +1,29 @@
+"""Add TextPlanet model
+
+Revision ID: 1e129b98f546
+Revises: 4e44fd06a62b
+Create Date: 2014-05-13 23:25:36.442683
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '1e129b98f546'
+down_revision = '4e44fd06a62b'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table('text_planet',
+    sa.Column('id', sa.String(length=32), nullable=False),
+    sa.Column('text', sa.Text(), nullable=True),
+    sa.ForeignKeyConstraint(['id'], ['planet.id'], ),
+    sa.PrimaryKeyConstraint('id')
+    )
+    ### end Alembic commands ###
+
+
+def downgrade():
+    op.drop_table('text_planet')
+    ### end Alembic commands ###

--- a/nucleus/models.py
+++ b/nucleus/models.py
@@ -946,9 +946,30 @@ class Star(Serializable, db.Model):
         return None
 
     def has_picture(self):
-        """Return True if this Star has a Picture-Planet"""
-        count = self.planet_assocs.join(PlanetAssociation.planet.of_type(LinkedPicturePlanet)).count()
-        return count > 0
+        """Return True if this Star has a PicturePlanet"""
+        try:
+            first = self.picture_planets()[0]
+        except IndexError:
+            first = None
+
+        return first is not None
+
+    def has_text(self):
+        """Return True if this Star has a TextPlanet"""
+        try:
+            first = self.text_planets()[0]
+        except IndexError:
+            first = None
+
+        return first is not None
+
+    def picture_planets(self):
+        """Return pictures of this Star"""
+        return self.planet_assocs.join(PlanetAssociation.planet.of_type(LinkedPicturePlanet)).all()
+
+    def text_planets(self):
+        """Return TextPlanets of this Star"""
+        return self.planet_assocs.join(PlanetAssociation.planet.of_type(TextPlanet)).all()
 
 
 class PlanetAssociation(db.Model):

--- a/static/css/main.less
+++ b/static/css/main.less
@@ -102,7 +102,7 @@ article {
     section {
         position: absolute;
         margin-bottom: 1em;
-        // overflow: hidden;
+        overflow: scroll;
 
         &.card {
             border-radius: 3px;
@@ -135,6 +135,19 @@ article {
             .content {
                 font-size: (@font-size * 2)/16*1em;
                 line-height: 1em;
+            }
+
+            .text.content {
+                font-size: (@font-size)/16*1em;
+                line-height: ((@font-size) * 1.5)/16*1em;
+
+                p {
+                    margin-bottom: ((@font-size) * 1.5)/16*1em;
+                }
+
+                h1,h2,h3 {
+                    margin: .7em 0 .3em;
+                }
             }
         }
 

--- a/static/css/main.less
+++ b/static/css/main.less
@@ -173,13 +173,20 @@ article {
             }
         }
 
-        .fullsize-input > textarea, .fullsize-input > input {
-            width: (22.8em);
-            height: 3em;
-            border: none;
-            resize: none;
-            box-shadow: none;
-            font-size: 1em;
+        .fullsize-input {
+            width: 95%;
+            height: 95%;
+            margin: 1% auto;
+
+            textarea, input {
+                width: 100%;
+                height: 100%;
+                border: none;
+                resize: none;
+                box-shadow: none;
+                font-size: 1em;
+                padding: 0;
+            }
         }
 
         .card-handle {

--- a/static/layouts.json
+++ b/static/layouts.json
@@ -98,7 +98,8 @@
         "context": ["create_star_page"],
         "create_star_form": [
             [0, 2, 5, 1],
-            [0, 3, 5, 1]
+            [0, 3, 5, 3],
+            [0, 6, 5, 1]
         ]
     },
     {

--- a/templates/macros/create_star.html
+++ b/templates/macros/create_star.html
@@ -4,10 +4,29 @@
 -->
 
 <form method="POST" action="{{url_for('create_star')}}" enctype="multipart/form-data">
-    <!-- Main text field -->
+    <!-- Title field -->
     <section class="textarea card {{ page.create_star_form[0].css_class }}">
         <div class="card-handle">
             <i class="fa fa-asterisk"></i>
+        </div>
+
+        <div class="sidenav">
+            {% if form.title.errors %}
+                {% for error in form.title.errors %}<small>{{ error }}</small>{% endfor %}
+            {% endif %}
+        </div>
+
+        <div class="fullsize-input">
+        {{ form.title(placeholder="Your message") }}
+        </div>
+        {{ form.csrf_token }}
+        {{ form.group_id }}
+    </section>
+
+    <!-- Main text field -->
+    <section class="textarea card {{ page.create_star_form[1].css_class }}">
+        <div class="card-handle">
+            <i class="fa fa-align-left"></i>
         </div>
 
         <div class="sidenav">
@@ -17,14 +36,14 @@
         </div>
 
         <div class="fullsize-input">
-        {{ form.text(placeholder="Enter your message") }}
+        {{ form.text(placeholder="Optional long text") }}
         </div>
         {{ form.csrf_token }}
         {{ form.group_id }}
     </section>
 
     <!-- Controls -->
-    <section class="{{ page.create_star_form[1].css_class }}">
+    <section class="{{ page.create_star_form[2].css_class }}">
         <span class="pull-right">
             <div class="btn-group">
                 <button type="submit" class="btn btn-default">

--- a/templates/macros/planet.html
+++ b/templates/macros/planet.html
@@ -12,5 +12,10 @@
 <!-- <span class="content link">
     <a href="{{ planet.url }}" />{{planet.url}}</a>
 </span> -->
+{% elif planet.kind == 'text' %}
+<span class="content text">
+    <p>{{ planet.text|markdown}}</p>
+</span>
 {% endif %}
+
 {% endmacro %}

--- a/templates/macros/planet.html
+++ b/templates/macros/planet.html
@@ -14,7 +14,7 @@
 </span> -->
 {% elif planet.kind == 'text' %}
 <span class="content text">
-    <p>{{ planet.text|markdown}}</p>
+    {{ planet.text|markdown}}
 </span>
 {% endif %}
 

--- a/templates/macros/star.html
+++ b/templates/macros/star.html
@@ -29,11 +29,13 @@
         </button>
     </span>
 
+    {% if controls == "extended" %}
     <span class="attribute">
         <span class="caption">
             <a href="{{ url_for('star', id=star.id) }}" title="{{star.created}}">{{star.created|naturaltime}}</a>
         </span>
     </span>
+    {% endif %}
 
     <span class="inline-semantic"> by </span>
 
@@ -90,7 +92,7 @@
 {% if controls == "extended" %}
 <div class="comment">
     <form action="{{ url_for('create_star', parent_id=star.id) }}" method="POST">
-            <input type="text" name="text" placeholder="write a comment as {{author.username}}...">
+            <input type="text" name="title" placeholder="write a comment as {{author.username}}...">
             <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
             <input type="hidden" name="author" value="{{ author.id }}">
             <input type="hidden" name="context" value="">
@@ -135,7 +137,7 @@
   </div>
   <div class="modal-footer">
     <form action="{{ url_for('create_star', parent_id=star.id) }}" method="POST">
-        <input type="text" name="text" placeholder="write a comment...">
+        <input type="text" name="title" placeholder="write a comment...">
         <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
         <input type="hidden" name="author" value="{{ author.id }}">
         <input type="hidden" name="context" value="">

--- a/templates/star.html
+++ b/templates/star.html
@@ -4,7 +4,11 @@
 
 {% block content %}
 {% if star.has_text() %}
-    <section class="col7 row1 w5 h4">
+    <section class="col1 row1 w6 h7">
+        {{ planet_macros.planet(star.text_planets()[0].planet, True) }}
+    </section>
+
+    <section class="col8 row1 w5 h4">
         {{ star_macros.star(star,
             author=active_persona,
             controlled_personas=controlled_personas,
@@ -13,12 +17,8 @@
         }}
     </section>
 
-    <section class="col2 row1 w5 h7">
-        {{ planet_macros.planet(star.text_planets()[0].planet, True) }}
-    </section>
-
     {% if star.children.filter_by(kind='star')[0] %}
-        <section class="col7 row4 w4 h4">
+        <section class="col8 row4 w4 h4">
             <h3 style="margin: 0 auto; color: #666">Comments</h3>
             <ul class="star_list">
             {% for star in star.children.filter_by(kind="star")[:4] %}

--- a/templates/star.html
+++ b/templates/star.html
@@ -3,7 +3,34 @@
 {% import "macros/planet.html" as planet_macros %}
 
 {% block content %}
-{% if star.has_picture() %}
+{% if star.has_text() %}
+    <section class="col7 row1 w5 h4">
+        {{ star_macros.star(star,
+            author=active_persona,
+            controlled_personas=controlled_personas,
+            controls="extended",
+            display_planets=False)
+        }}
+    </section>
+
+    <section class="col2 row1 w5 h7">
+        {{ planet_macros.planet(star.text_planets()[0].planet, True) }}
+    </section>
+
+    {% if star.children.filter_by(kind='star')[0] %}
+        <section class="col7 row4 w4 h4">
+            <h3 style="margin: 0 auto; color: #666">Comments</h3>
+            <ul class="star_list">
+            {% for star in star.children.filter_by(kind="star")[:4] %}
+                <li class="{% if star.has_picture() %}rel-blend image-overlay{% endif %}">
+                {{ star_macros.star(star, author=active_persona, controlled_personas=controlled_personas, display_planets=True) }}
+                </li>
+                <div style="margin-bottom: 1em;"></div>
+            {% endfor %}
+        </ul>
+        </section>
+    {% endif %}
+{% elif star.has_picture() %}
     {% for planet_assoc in star.planet_assocs %}
     <section class="col2 row1 w5 h7">
         {{ planet_macros.planet(planet_assoc.planet, True) }}

--- a/web_ui/__init__.py
+++ b/web_ui/__init__.py
@@ -7,6 +7,7 @@ from flask.ext import uploads
 import logging
 from logging.handlers import RotatingFileHandler
 from flask.ext.sqlalchemy import SQLAlchemy
+from flask.ext.misaka import Misaka
 
 # Initialize Flask app
 app = Flask('souma')
@@ -18,6 +19,9 @@ app.config.from_object("web_ui.default_config")
 app.config.from_object('astrolab.config')
 
 app.jinja_env.filters['naturaltime'] = naturaltime
+
+# Register markdown filters
+Misaka(app)
 
 # Create application data folder
 if not os.path.exists(app.config["USER_DATA"]):

--- a/web_ui/forms.py
+++ b/web_ui/forms.py
@@ -15,7 +15,8 @@ class Create_star_form(Form):
     # Choices of the author field need to be set before displaying the form
     # TODO: Validate author selection
     author = SelectField('Author', validators=[DataRequired(), ])
-    text = TextAreaField('Content', validators=[DataRequired(), ])
+    title = TextAreaField('Title', validators=[DataRequired(), ])
+    text = TextAreaField('Content', validators=[])
     # picture = FileField('Picture')
     linkedpicture = URLField('Picture')
     link = URLField('Link')

--- a/web_ui/views.py
+++ b/web_ui/views.py
@@ -314,7 +314,7 @@ def create_star():
                 app.logger.info("Attached {} to new {}".format(planet, new_star))
 
         # Add longform text field as attachment
-        if 'text' in request.values:
+        if 'text' in request.values and len(request.form["text"]) > 0:
             planet = TextPlanet.get_or_create(request.form['text'])
             assoc = PlanetAssociation(star=new_star, planet=planet, author=author)
             new_star.planet_assocs.append(assoc)


### PR DESCRIPTION
- [x] Add TextPlanet model
- [x] Add text field to create_star macro
- [x] Make text field optional in create_star macro (e.g. for group page)
- [x] Add text field to create_star form
- [x] Attach submitted text to new Stars
- [x] Adapt star template to show text attachment if available
- [x] Prevent creating TextPlanet when text field is empty
- [x] Check whether TextPlanet sync works
- [ ] Check whether db migration works
